### PR TITLE
Keep pipe open; handle empty body

### DIFF
--- a/Release/src/http/listener/http_server_named_pipe.h
+++ b/Release/src/http/listener/http_server_named_pipe.h
@@ -85,7 +85,6 @@ private:
     static void parse_http_headers(std::istream* request_stream, http::http_headers& headers);
 
     web::http::experimental::listener::details::http_listener_impl* m_listener;
-    std::vector<unsigned char> m_body_data;
 
     HANDLE m_pipeHandle;
     TP_IO* m_threadpool_io;


### PR DESCRIPTION
Fixing issues exposed by DSC REST Server UTs: client needs to handle empty bodies and needs to keep the named pipe open in case the same client is used for a second request (will add cleanup of the handle in next PR; for the moment I want to add this to do integration with dsc).