### PR TITLE
flush data from http server before closing pipe connection

### DIFF
--- a/Release/src/http/listener/http_server_api.cpp
+++ b/Release/src/http/listener/http_server_api.cpp
@@ -10,6 +10,7 @@
 ****/
 
 #include "stdafx.h"
+#define DSC_FORCE_HTTP_LISTENER_NAMED_PIPE 1
 
 #if !defined(_WIN32) || (_WIN32_WINNT >= _WIN32_WINNT_VISTA && !defined(__cplusplus_winrt)) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
 #include "http_server_impl.h"

--- a/Release/src/http/listener/http_server_named_pipe.cpp
+++ b/Release/src/http/listener/http_server_named_pipe.cpp
@@ -98,7 +98,7 @@ named_pipe_request_context::~named_pipe_request_context()
 
     if (m_pipeHandle != nullptr)
     {
-        // TODO: Need to FlushFileBuffers before disconnecting (https://msdn.microsoft.com/en-us/library/windows/desktop/aa365598(v=vs.85).aspx)
+        FlushFileBuffers(m_pipeHandle);
         DisconnectNamedPipe(m_pipeHandle);
         CloseHandle(m_pipeHandle);
     }


### PR DESCRIPTION
WriteFile does not guarantee that data will be written to the pipes. http server is immediately closing pipe handle after WriteFile call. because of that sometimes http client fails to receive the data.

Now flushing the data before closing the handle, it will make sure data is received at client side before pipe connection is closed. 