### PR TITLE
Fix pipe instances busy error by pipe client.

### DIFF
--- a/Release/src/http/client/http_client_named_pipe.cpp
+++ b/Release/src/http/client/http_client_named_pipe.cpp
@@ -260,28 +260,28 @@ protected:
                 0,
                 NULL);
 
-			if (m_namedPipe != INVALID_HANDLE_VALUE)
-			{
-				break;
-			}
+            if (m_namedPipe != INVALID_HANDLE_VALUE)
+            {
+                break;
+            }
             auto errorCode = GetLastError();
-			if (errorCode != ERROR_PIPE_BUSY)
-			{
-				named_pipe_context->report_error(errorCode, build_error_msg(errorCode, "Error opening named pipe"));
-				break;
-			}
-			else
-			{
-				// Wait for pipe instance to be avialabe, upto 10 sec(pipe server specified default)
-				if (!WaitNamedPipe(pipe_name.c_str(), NMPWAIT_USE_DEFAULT_WAIT))
-				{
-					if (retry_count <= 0)
+            if (errorCode != ERROR_PIPE_BUSY)
+            {
+                named_pipe_context->report_error(errorCode, build_error_msg(errorCode, "Error opening named pipe"));
+                break;
+            }
+            else
+            {
+                // Wait for pipe instance to be avialabe, upto 10 sec(pipe server specified default)
+                if (!WaitNamedPipe(pipe_name.c_str(), NMPWAIT_USE_DEFAULT_WAIT))
+                {
+                    if (retry_count <= 0)
                     {
-					    named_pipe_context->report_error(errorCode, build_error_msg(errorCode, "Could not open pipe: 10 second wait timed out and made 3 attempts."));
+                        named_pipe_context->report_error(errorCode, build_error_msg(errorCode, "Could not open pipe: 10 second wait timed out and made 3 attempts."));
                         break;
                     }   
-				}
-			}
+                }
+            }
         }
 
         if (m_namedPipe == INVALID_HANDLE_VALUE)

--- a/Release/src/http/client/http_client_named_pipe.cpp
+++ b/Release/src/http/client/http_client_named_pipe.cpp
@@ -275,7 +275,7 @@ protected:
 				// Wait for pipe instance to be avialabe, upto 10 sec(pipe server specified default)
 				if (!WaitNamedPipe(pipe_name.c_str(), NMPWAIT_USE_DEFAULT_WAIT))
 				{
-					if (retry_count == 0)
+					if (retry_count <= 0)
                     {
 					    named_pipe_context->report_error(errorCode, build_error_msg(errorCode, "Could not open pipe: 10 second wait timed out and made 3 attempts."));
                         break;

--- a/Release/src/http/client/http_client_named_pipe.cpp
+++ b/Release/src/http/client/http_client_named_pipe.cpp
@@ -272,11 +272,14 @@ protected:
 			}
 			else
 			{
-				// Wait for pipe instance to be avialabe, upto 20 sec(pipe server specified default)
+				// Wait for pipe instance to be avialabe, upto 10 sec(pipe server specified default)
 				if (!WaitNamedPipe(pipe_name.c_str(), NMPWAIT_USE_DEFAULT_WAIT))
 				{
 					if (retry_count == 0)
-					named_pipe_context->report_error(errorCode, build_error_msg(errorCode, "Could not open pipe: 20 second wait timed out and made 3 attempts."));
+                    {
+					    named_pipe_context->report_error(errorCode, build_error_msg(errorCode, "Could not open pipe: 10 second wait timed out and made 3 attempts."));
+                        break;
+                    }   
 				}
 			}
         }

--- a/Release/src/http/listener/http_server_named_pipe.cpp
+++ b/Release/src/http/listener/http_server_named_pipe.cpp
@@ -40,9 +40,7 @@ using namespace http::experimental::details;
 #define CRLF std::string("\r\n")
 #define CRLFCRLF std::string("\r\n\r\n")
 
-// Maximum number of concurrent named pipe instances (1 instance per request).
-const DWORD MAX_NUMBER_OF_CONCURRENT_REQUESTS = 128;
-const DWORD nDefaultTimeOut = 20000;  // clients wait upto 20 sec for pipe instance to be available when all pipe instances are busy.
+const DWORD nDefaultTimeOut = 10000;  // clients wait upto 10 sec for pipe instance to be available when all pipe instances are busy.
 
 namespace web
 {
@@ -554,7 +552,7 @@ void named_pipe_listener::async_receive_request()
         pipe_name.c_str(),
         PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
         PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
-        MAX_NUMBER_OF_CONCURRENT_REQUESTS,
+        PIPE_UNLIMITED_INSTANCES,
         PIPE_BUFFER_SIZE,
         PIPE_BUFFER_SIZE,
         0,

--- a/Release/src/http/listener/http_server_named_pipe.cpp
+++ b/Release/src/http/listener/http_server_named_pipe.cpp
@@ -555,7 +555,7 @@ void named_pipe_listener::async_receive_request()
         PIPE_UNLIMITED_INSTANCES,
         PIPE_BUFFER_SIZE,
         PIPE_BUFFER_SIZE,
-        0,
+        nDefaultTimeOut,
         &security_attributes);
 
     if (pipeHandle == INVALID_HANDLE_VALUE)

--- a/Release/src/http/listener/http_server_named_pipe.cpp
+++ b/Release/src/http/listener/http_server_named_pipe.cpp
@@ -42,6 +42,7 @@ using namespace http::experimental::details;
 
 // Maximum number of concurrent named pipe instances (1 instance per request).
 const DWORD MAX_NUMBER_OF_CONCURRENT_REQUESTS = 128;
+const DWORD nDefaultTimeOut = 20000;  // clients wait upto 20 sec for pipe instance to be available when all pipe instances are busy.
 
 namespace web
 {


### PR DESCRIPTION
- Allow clients to wait until server pipe instance is available to connect. 
- Make concurrent client limit to the max allowed by the system.