### PR TITLE
Increasing timeout of http_client object

### DIFF
--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -81,8 +81,8 @@ class http_client_config
 public:
     http_client_config() :
         m_guarantee_order(false),
-// Set the default http_client time out to 5 minutes.
-        m_timeout(std::chrono::seconds(300)),
+// Set the default http_client time out to 20 minutes (originally set to 5 minutes, but we need more time to run our inGuest scenario)
+        m_timeout(std::chrono::seconds(1200)),
         m_chunksize(0),
         m_request_compressed(false)
 #if !defined(__cplusplus_winrt)

--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -81,8 +81,9 @@ class http_client_config
 public:
     http_client_config() :
         m_guarantee_order(false),
-// Set the default http_client time out to 20 minutes (originally set to 5 minutes, but we need more time to run our inGuest scenario)
-        m_timeout(std::chrono::seconds(1200)),
+// Set the default http_client time out to 30 minutes (originally set to 5 minutes, but we need more time to run our inGuest scenario)
+// We shouldn't need the full 20 minutes, but want to play it safe.
+        m_timeout(std::chrono::seconds(1800)),
         m_chunksize(0),
         m_request_compressed(false)
 #if !defined(__cplusplus_winrt)

--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1055,7 +1055,6 @@ private:
                 if (ec.value() == 125)
                 {
                     error_msg = "Failed to read HTTP status line due to http_client object reaching maximum timeout.: error category: " + category + " error message: " + ec.message() + " error value: " + std::to_string(ec.value());
-                    std::cout << error_msg << std::endl;
                 }
                 else
                 {


### PR DESCRIPTION
This is a mitigation for the "Failed to read http_status line" error that comes up intermittently when there are multiple policies running on a Linux machine. The original timeout for the http_client object was 5 minutes, and when we're running multiple policies at the same time, this is often not enough time for them to all complete. I tried increasing the time to 10 minutes, but a couple of machines that were running 6 policies were still not completing in the allotted time, so increasing to 20 minutes.

This is only a mitigation since we could still hit this issue in the future if a machine had many policies (>10) running on a machine. To further fix this problem, we need to update our run_consistency timer logic to space out when the policies run so that they aren't all running at the same time.

Another option to further fix this problem is to force each consistency run to finish once it creates the http_client object (which manages the socket connection) before queuing the next policy . Currently, all of the policies start the run_consistency run and open the socket before any of them actually start executing which is what causes some of them to timeout.