### PR TITLE
Support white spaces in posted messages.

### DIFF
--- a/Release/src/http/listener/http_server_named_pipe.cpp
+++ b/Release/src/http/listener/http_server_named_pipe.cpp
@@ -175,7 +175,8 @@ void named_pipe_request_context::on_request_received(DWORD error_code, DWORD byt
     auto body = request_body_buf.alloc(bodySize);
 
     std::string tmp;
-    request_stream >> tmp;
+	std::getline(request_stream, tmp);
+
     memcpy(body, tmp.c_str(), bodySize);
 
     request_body_buf.commit(bodySize);


### PR DESCRIPTION
issue here is we are using  '>>' to read the istringstream of the request and that does not read the entire string.  replaced it with getline to read entire string that the client wrote.