### PR TITLE
Set http_client default timeout to 60 mins.

### DIFF
--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -81,9 +81,8 @@ class http_client_config
 public:
     http_client_config() :
         m_guarantee_order(false),
-// Set the default http_client time out to 30 minutes (originally set to 5 minutes, but we need more time to run our inGuest scenario)
-// We shouldn't need the full 20 minutes, but want to play it safe.
-        m_timeout(std::chrono::seconds(1800)),
+        // Set the default http_client time out to 60 minutes (originally set to 5 minutes, but we need more time to run our inGuest scenario)
+        m_timeout(std::chrono::seconds(3600)),
         m_chunksize(0),
         m_request_compressed(false)
 #if !defined(__cplusplus_winrt)


### PR DESCRIPTION
GuestConfiguration Builtin policy execution (to check the compliance status) finishes within the current timeout limit (30mins) but Custom Policy customer are open to write any configuration and their policy can take more time.

Increasing the timeout to 60 mins. Later we will make the timeout configurable. 
Link to the work item to make the timeout configurable : https://msazure.visualstudio.com/One/_workitems/edit/4840347